### PR TITLE
Feature: Support foreign states such as extranjero, ne or foreign for…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2025-02-28
+### Added
+  - Support for foreign states such as `extranjero`, `ne` or `foreign` for `birth_state` parameter.
+
 ## [1.2.0] - 2024-11-26
 ### Changed
   - Updated required Ruby version for development to `3.2.2`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The main class is `CurpGenerator::Curp`. It accepts the following parameters:
 |`second_last_name`|`String`|The mother's last name of the person.|
 |`gender`|`String`|The gender of the person. Possible values: `male`, `female`, `hombre`, `mujer`, `femenino`, `masculino`, `h (male)`, `m (female)` (case insensitive).|
 |`birth_date`|`DateTime`|The date when the person was born.|
-|`birth_state`|`String`|The mexican state where the person was born. Possible values are listed in the [Catalogs module](/lib/curp_generator/catalogs.rb).|
+|`birth_state`|`String`|The mexican state where the person was born. Possible values are listed in the [Catalogs module](/lib/curp_generator/catalogs.rb). In case of foreign nationals, send `foreign`, `ne` or `extranjero`. |
 
 Then, just call the `.generate` method and it will return the CURP for that person.
 

--- a/lib/curp_generator/catalogs.rb
+++ b/lib/curp_generator/catalogs.rb
@@ -99,7 +99,10 @@ module CurpGenerator
       'YUC'                   => 'YN',
       'ZACATECAS'             => 'ZS',
       'ZA'                    => 'ZS',
-      'ZAC'                   => 'ZS'
+      'ZAC'                   => 'ZS',
+      'EXTRANJERO'            => 'NE',
+      'NE'                    => 'NE',
+      'FOREIGN'               => 'NE'
     }.freeze
 
     FORBIDDEN_WORDS = {

--- a/lib/curp_generator/version.rb
+++ b/lib/curp_generator/version.rb
@@ -1,3 +1,3 @@
 module CurpGenerator
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.3.0'.freeze
 end

--- a/spec/unit/state_spec.rb
+++ b/spec/unit/state_spec.rb
@@ -58,8 +58,20 @@ RSpec.describe CurpGenerator::State do
     end
 
     context 'when is a foreign location' do
-      context 'and is a valid mexican state' do
+      context 'and is not a valid mexican state' do
         let(:state) { 'USA' }
+
+        it 'returns state foreign characters' do
+          expect(subject.generate).to eq('NE')
+        end
+
+        it 'returns two characters' do
+          expect(subject.generate.size).to eq(2)
+        end
+      end
+
+      context 'and the value is foreign, ne or extranjero' do
+        let(:state) { ['foreign', 'ne', 'extranjero'].sample }
 
         it 'returns state foreign characters' do
           expect(subject.generate).to eq('NE')


### PR DESCRIPTION
# Changes

- Aceptar `extranjero`, `ne` y foreign a `CurpGenerator::State#generate` para retornar `NE` como un extranjero.